### PR TITLE
docs: don't show raw backtics for code

### DIFF
--- a/apps/maestros/app/globals.css
+++ b/apps/maestros/app/globals.css
@@ -80,3 +80,16 @@
 .react-flow__node-group {
   padding: 0 !important;
 }
+
+.prose :where(code):not(:where([class~="not-prose"] *))::after {
+  content: none !important;
+}
+
+.prose :where(code):not(:where([class~="not-prose"] *))::before {
+  content: none !important;
+}
+
+.prose code {
+  @apply bg-gray-100 dark:bg-gray-800 rounded-md py-1 px-1;
+}
+

--- a/apps/maestros/app/globals.css
+++ b/apps/maestros/app/globals.css
@@ -81,15 +81,14 @@
   padding: 0 !important;
 }
 
-.prose :where(code):not(:where([class~="not-prose"] *))::after {
+.prose :where(code):not(:where([class~='not-prose'] *))::after {
   content: none !important;
 }
 
-.prose :where(code):not(:where([class~="not-prose"] *))::before {
+.prose :where(code):not(:where([class~='not-prose'] *))::before {
   content: none !important;
 }
 
 .prose code {
   @apply bg-gray-100 dark:bg-gray-800 rounded-md py-1 px-1;
 }
-


### PR DESCRIPTION
Good looking change but maybe there is a better way or reason all the folks love seeing the rawdawg ``

tagging the boys who know more about tailwind as well @PickleNik @maxdemaio

Before:
![image](https://github.com/anthonyshew/maestros/assets/996134/30debf33-65f0-4e93-875f-5fed747ab10a)
![image](https://github.com/anthonyshew/maestros/assets/996134/4f117ee4-52cd-4884-8213-691c2d3132da)

After:
![image](https://github.com/anthonyshew/maestros/assets/996134/6e0e6922-01fc-4858-8b7d-c77fcaea1d36)
![image](https://github.com/anthonyshew/maestros/assets/996134/d23567f9-3d44-4119-ae6c-66f3ed5c2a7b)
