### PR TITLE
Update generate workspace command

### DIFF
--- a/apps/maestros/content/maestros/lessons/try-it-out/thinking-in-graphs.mdx
+++ b/apps/maestros/content/maestros/lessons/try-it-out/thinking-in-graphs.mdx
@@ -46,7 +46,7 @@ This is a simple pipeline with few steps. In the left sidebar, you can change th
 You can copy the "Turbo Studio" workspace into your project using [Turborepo Generators](https://turbo.build/repo/docs/core-concepts/monorepos/code-generation).
 
 ```bash filename="Terminal"
-turbo generate workspace https://github.com/anthonyshew/maestros/tree/main/apps/studio
+turbo generate workspace -c https://github.com/anthonyshew/maestros/tree/main/apps/studio
 # > Follow the prompts. You don't need to install any workspace dependencies.
 pnpm install # or your package manager
 turbo start:studio


### PR DESCRIPTION
#97 The Terminal code example for generating the studio workspace seems to be outdated. It needs the '-c' argument before the github URL in order to work

