### PR TITLE
Fix `turbo.json` typecheck example

### DIFF
--- a/apps/maestros/content/maestros/lessons/guardrails/typescript.mdx
+++ b/apps/maestros/content/maestros/lessons/guardrails/typescript.mdx
@@ -135,7 +135,7 @@ Now, we'll build our Turborepo pipeline with two important characteristics.
       "dependsOn": ["^topo"]
     },
     "typecheck": {
-      "dependsOn": ["^topo"],
+      "dependsOn": ["topo"],
       "outputs": ["node_modules/.cache/tsbuildinfo.json"]
     }
   }


### PR DESCRIPTION
The Turborepo docs outlining the `topo` trick specify that package tasks should rely on the current package's `topo` task, not the dependencies `topo` task

copy/paste from the Turborepo docs:

```json
{
  "$schema": "https://turbo.build/schema.json",
   "pipeline": {
     "topo": {
       "dependsOn": ["^topo"]
     },
     "your-task": {
       "dependsOn": ["topo"]
     }
   }
 }
```