### PR TITLE
Upgrade Turborepo to v2.5.4

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -26,5 +26,5 @@ jobs:
       - name: Setup
         uses: ./tooling/github-actions/setup
 
-      - name: Run formatter
-        run: pnpm checks
+      - name: Run checks
+        run: turbo run format lint typecheck spellcheck --continue

--- a/apps/maestros/turbo.json
+++ b/apps/maestros/turbo.json
@@ -1,14 +1,8 @@
 {
 	"extends": ["//"],
-	"pipeline": {
+	"tasks": {
 		"build": {
 			"outputs": ["./next/**", "!./next/cache/**", ".contentlayer/**"],
-			"dotEnv": [
-				".env.production.local",
-				".env.local",
-				".env.production",
-				".env"
-			],
 			"env": [
 				"GH_CLIENT_ID",
 				"GH_CLIENT_SECRET",
@@ -25,13 +19,7 @@
 			]
 		},
 		"dev": {
-			"persistent": true,
-			"dotEnv": [
-				".env.development.local",
-				".env.local",
-				".env.development",
-				".env"
-			]
+			"persistent": true
 		}
 	}
 }

--- a/apps/studio/turbo.json
+++ b/apps/studio/turbo.json
@@ -1,6 +1,6 @@
 {
 	"extends": ["//"],
-	"pipeline": {
+	"tasks": {
 		"dev:studio": {
 			"dependsOn": [],
 			"persistent": true,

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.0.6",
-		"turbo": "^1.11.2"
+		"turbo": "^2.5.4"
 	},
 	"packageManager": "pnpm@10.12.4",
 	"engines": {

--- a/packages/db/turbo.json
+++ b/packages/db/turbo.json
@@ -1,10 +1,9 @@
 {
 	"extends": ["//"],
 	"globalEnv": ["NODE_ENV"],
-	"pipeline": {
+	"tasks": {
 		"db:generate": {
-			"outputs": ["../../node_modules/.prisma/**"],
-			"outputMode": "new-only"
+			"outputs": ["../../node_modules/.prisma/**"]
 		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,8 @@ importers:
         specifier: 2.0.6
         version: 2.0.6
       turbo:
-        specifier: ^1.11.2
-        version: 1.11.2
+        specifier: ^2.5.4
+        version: 2.5.4
 
   apps/maestros:
     dependencies:
@@ -4936,38 +4936,38 @@ packages:
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
 
-  turbo-darwin-64@1.11.2:
-    resolution: {integrity: sha512-toFmRG/adriZY3hOps7nYCfqHAS+Ci6xqgX3fbo82kkLpC6OBzcXnleSwuPqjHVAaRNhVoB83L5njcE9Qwi2og==}
+  turbo-darwin-64@2.5.4:
+    resolution: {integrity: sha512-ah6YnH2dErojhFooxEzmvsoZQTMImaruZhFPfMKPBq8sb+hALRdvBNLqfc8NWlZq576FkfRZ/MSi4SHvVFT9PQ==}
     cpu: [x64]
     os: [darwin]
 
-  turbo-darwin-arm64@1.11.2:
-    resolution: {integrity: sha512-FCsEDZ8BUSFYEOSC3rrARQrj7x2VOrmVcfrMUIhexTxproRh4QyMxLfr6LALk4ymx6jbDCxWa6Szal8ckldFbA==}
+  turbo-darwin-arm64@2.5.4:
+    resolution: {integrity: sha512-2+Nx6LAyuXw2MdXb7pxqle3MYignLvS7OwtsP9SgtSBaMlnNlxl9BovzqdYAgkUW3AsYiQMJ/wBRb7d+xemM5A==}
     cpu: [arm64]
     os: [darwin]
 
-  turbo-linux-64@1.11.2:
-    resolution: {integrity: sha512-Vzda/o/QyEske5CxLf0wcu7UUS+7zB90GgHZV4tyN+WZtoouTvbwuvZ3V6b5Wgd3OJ/JwWR0CXDK7Sf4VEMr7A==}
+  turbo-linux-64@2.5.4:
+    resolution: {integrity: sha512-5May2kjWbc8w4XxswGAl74GZ5eM4Gr6IiroqdLhXeXyfvWEdm2mFYCSWOzz0/z5cAgqyGidF1jt1qzUR8hTmOA==}
     cpu: [x64]
     os: [linux]
 
-  turbo-linux-arm64@1.11.2:
-    resolution: {integrity: sha512-bRLwovQRz0yxDZrM4tQEAYV0fBHEaTzUF0JZ8RG1UmZt/CqtpnUrJpYb1VK8hj1z46z9YehARpYCwQ2K0qU4yw==}
+  turbo-linux-arm64@2.5.4:
+    resolution: {integrity: sha512-/2yqFaS3TbfxV3P5yG2JUI79P7OUQKOUvAnx4MV9Bdz6jqHsHwc9WZPpO4QseQm+NvmgY6ICORnoVPODxGUiJg==}
     cpu: [arm64]
     os: [linux]
 
-  turbo-windows-64@1.11.2:
-    resolution: {integrity: sha512-LgTWqkHAKgyVuLYcEPxZVGPInTjjeCnN5KQMdJ4uQZ+xMDROvMFS2rM93iQl4ieDJgidwHCxxCxaU9u8c3d/Kg==}
+  turbo-windows-64@2.5.4:
+    resolution: {integrity: sha512-EQUO4SmaCDhO6zYohxIjJpOKRN3wlfU7jMAj3CgcyTPvQR/UFLEKAYHqJOnJtymbQmiiM/ihX6c6W6Uq0yC7mA==}
     cpu: [x64]
     os: [win32]
 
-  turbo-windows-arm64@1.11.2:
-    resolution: {integrity: sha512-829aVBU7IX0c/B4G7g1VI8KniAGutHhIupkYMgF6xPkYVev2G3MYe6DMS/vsLt9GGM9ulDtdWxWrH5P2ngK8IQ==}
+  turbo-windows-arm64@2.5.4:
+    resolution: {integrity: sha512-oQ8RrK1VS8lrxkLriotFq+PiF7iiGgkZtfLKF4DDKsmdbPo0O9R2mQxm7jHLuXraRCuIQDWMIw6dpcr7Iykf4A==}
     cpu: [arm64]
     os: [win32]
 
-  turbo@1.11.2:
-    resolution: {integrity: sha512-jPC7LVQJzebs5gWf8FmEvsvXGNyKbN+O9qpvv98xpNaM59aS0/Irhd0H0KbcqnXfsz7ETlzOC3R+xFWthC4Z8A==}
+  turbo@2.5.4:
+    resolution: {integrity: sha512-kc8ZibdRcuWUG1pbYSBFWqmIjynlD8Lp7IB6U3vIzvOv9VG+6Sp8bzyeBWE3Oi8XV5KsQrznyRTBPvrf99E4mA==}
     hasBin: true
 
   typanion@3.14.0:
@@ -11080,32 +11080,32 @@ snapshots:
       tslib: 1.14.1
       typescript: 5.8.3
 
-  turbo-darwin-64@1.11.2:
+  turbo-darwin-64@2.5.4:
     optional: true
 
-  turbo-darwin-arm64@1.11.2:
+  turbo-darwin-arm64@2.5.4:
     optional: true
 
-  turbo-linux-64@1.11.2:
+  turbo-linux-64@2.5.4:
     optional: true
 
-  turbo-linux-arm64@1.11.2:
+  turbo-linux-arm64@2.5.4:
     optional: true
 
-  turbo-windows-64@1.11.2:
+  turbo-windows-64@2.5.4:
     optional: true
 
-  turbo-windows-arm64@1.11.2:
+  turbo-windows-arm64@2.5.4:
     optional: true
 
-  turbo@1.11.2:
+  turbo@2.5.4:
     optionalDependencies:
-      turbo-darwin-64: 1.11.2
-      turbo-darwin-arm64: 1.11.2
-      turbo-linux-64: 1.11.2
-      turbo-linux-arm64: 1.11.2
-      turbo-windows-64: 1.11.2
-      turbo-windows-arm64: 1.11.2
+      turbo-darwin-64: 2.5.4
+      turbo-darwin-arm64: 2.5.4
+      turbo-linux-64: 2.5.4
+      turbo-linux-arm64: 2.5.4
+      turbo-windows-64: 2.5.4
+      turbo-windows-arm64: 2.5.4
 
   typanion@3.14.0: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,5 @@
 {
-	"pipeline": {
+	"tasks": {
 		"dev": {
 			"dependsOn": ["@repo/db#generate"],
 			"persistent": true,
@@ -32,8 +32,7 @@
 			"cache": false
 		},
 		"typecheck": {
-			"dependsOn": ["^topo", "^generate", "generate"],
-			"outputMode": "errors-only"
+			"dependsOn": ["^topo", "^generate", "generate"]
 		},
 		"spellcheck": {
 			"inputs": ["**/*.mdx"],


### PR DESCRIPTION
## Summary
• Upgrade Turborepo from v1.11.2 to v2.5.4 with full configuration migration
• Update all turbo.json files to use new v2 format (pipeline → tasks, remove deprecated keys)

## Test plan
- [x] Run `pnpm run checks` to verify all tasks execute successfully
- [x] Confirm format, lint, typecheck, and spellcheck tasks complete without errors
- [x] Validate configuration migration handles breaking changes properly

🤖 Generated with [opencode](https://opencode.ai)