### PR TITLE
Update Node.js version from 18 to 22

### DIFF
--- a/apps/family-app/package.json
+++ b/apps/family-app/package.json
@@ -22,7 +22,7 @@
 		"@repo/tailwind-config": "workspace:*",
 		"@repo/tsconfig": "workspace:*",
 		"@tailwindcss/postcss": "^4",
-		"@types/node": "^20",
+		"@types/node": "^22",
 		"@types/react": "^19",
 		"@types/react-dom": "^19",
 		"@types/web-push": "^3.6.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,8 +61,8 @@ importers:
         specifier: ^4
         version: 4.1.11
       '@types/node':
-        specifier: ^20
-        version: 20.19.7
+        specifier: ^22
+        version: 22.16.5
       '@types/react':
         specifier: ^19
         version: 19.1.8
@@ -1222,8 +1222,8 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
-  '@types/node@20.19.7':
-    resolution: {integrity: sha512-1GM9z6BJOv86qkPvzh2i6VW5+VVrXxCLknfmTkWEqz+6DqosiY28XUWCTmBcJ0ACzKqx/iwdIREfo1fwExIlkA==}
+  '@types/node@22.16.5':
+    resolution: {integrity: sha512-bJFoMATwIGaxxx8VJPeM8TonI8t579oRvgAuT8zFugJsJZgzqv0Fu8Mhp68iecjzG7cnN3mO2dJQ5uUM2EFrgQ==}
 
   '@types/node@24.0.10':
     resolution: {integrity: sha512-ENHwaH+JIRTDIEEbDK6QSQntAYGtbvdDXnMXnZaZ6k13Du1dPMmprkEHIL7ok2Wl2aZevetwTAb5S+7yIF+enA==}
@@ -3243,7 +3243,7 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
-  '@types/node@20.19.7':
+  '@types/node@22.16.5':
     dependencies:
       undici-types: 6.21.0
 
@@ -3265,7 +3265,7 @@ snapshots:
 
   '@types/web-push@3.6.4':
     dependencies:
-      '@types/node': 24.0.10
+      '@types/node': 22.16.5
 
   '@ungap/structured-clone@1.3.0': {}
 

--- a/tooling/github-actions/setup/action.yml
+++ b/tooling/github-actions/setup/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 22
 
     - shell: bash
       run: npm i -g pnpm turbo


### PR DESCRIPTION
## Summary
- Updates @types/node from ^20 to ^22 in family-app package.json
- Updates GitHub Actions setup to use Node.js 22 instead of 18
- Updates pnpm lockfile with corresponding dependency changes

🤖 Generated with [Claude Code](https://claude.ai/code)