### PR TITLE
Refactor family-app imports to use Node.js subpath pattern

### DIFF
--- a/apps/family-app/app/api/meals/day/route.ts
+++ b/apps/family-app/app/api/meals/day/route.ts
@@ -1,6 +1,6 @@
 import { generateObject } from "ai";
 import { Effect } from "effect";
-import { mealSchema } from "../../../../lib/schemas";
+import { mealSchema } from "#/lib/schemas";
 
 export const maxDuration = 30;
 

--- a/apps/family-app/app/api/meals/week/route.ts
+++ b/apps/family-app/app/api/meals/week/route.ts
@@ -1,6 +1,6 @@
 import { generateObject } from "ai";
 import { Effect } from "effect";
-import { mealPlanSchema } from "../../../../lib/schemas";
+import { mealPlanSchema } from "#/lib/schemas";
 
 export const maxDuration = 30;
 

--- a/apps/family-app/app/api/recipe/route.ts
+++ b/apps/family-app/app/api/recipe/route.ts
@@ -1,6 +1,6 @@
 import { generateObject } from "ai";
 import { Effect } from "effect";
-import { recipeSchema } from "../../../lib/schemas";
+import { recipeSchema } from "#/lib/schemas";
 
 export const maxDuration = 30;
 

--- a/apps/family-app/app/page.tsx
+++ b/apps/family-app/app/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { Chat } from "../components/chat";
-import { InstallPrompt } from "../components/install-prompt";
-import { MealPlanner } from "../components/meal-planner";
-import { PushNotificationManager } from "../components/push-notification-manager";
-import { Recipe } from "../components/recipe";
+import { Chat } from "#/components/chat";
+import { InstallPrompt } from "#/components/install-prompt";
+import { MealPlanner } from "#/components/meal-planner";
+import { PushNotificationManager } from "#/components/push-notification-manager";
+import { Recipe } from "#/components/recipe";
 
 export default function Home() {
 	return (

--- a/apps/family-app/components/meal-planner.tsx
+++ b/apps/family-app/components/meal-planner.tsx
@@ -2,8 +2,8 @@
 
 import { experimental_useObject as useObject } from "@ai-sdk/react";
 import { useEffect, useState } from "react";
-import { mealPlanSchema, mealSchema } from "../lib/schemas";
-import type { Meal } from "../lib/types";
+import { mealPlanSchema, mealSchema } from "#/lib/schemas";
+import type { Meal } from "#/lib/types";
 
 export function MealPlanner() {
 	const [isRegeneratingFor, setIsRegeneratingFor] = useState<string | null>(

--- a/apps/family-app/components/push-notification-manager.tsx
+++ b/apps/family-app/components/push-notification-manager.tsx
@@ -6,8 +6,8 @@ import {
 	sendNotification,
 	subscribeUser,
 	unsubscribeUser,
-} from "../app/actions";
-import { urlBase64ToUint8Array } from "../lib/utils";
+} from "#/app/actions";
+import { urlBase64ToUint8Array } from "#/lib/utils";
 
 export function PushNotificationManager() {
 	const [isSupported, setIsSupported] = useState(false);

--- a/apps/family-app/components/recipe.tsx
+++ b/apps/family-app/components/recipe.tsx
@@ -2,8 +2,8 @@
 
 import { experimental_useObject as useObject } from "@ai-sdk/react";
 import { useState } from "react";
-import { recipeSchema } from "../lib/schemas";
-import type { RecipeType } from "../lib/types";
+import { recipeSchema } from "#/lib/schemas";
+import type { RecipeType } from "#/lib/types";
 
 export function Recipe() {
 	const [selectedMeal, setSelectedMeal] = useState("");

--- a/apps/family-app/package.json
+++ b/apps/family-app/package.json
@@ -30,5 +30,8 @@
 		"@types/web-push": "^3.6.4",
 		"tailwindcss": "^4",
 		"typescript": "^5"
+	},
+	"imports": {
+		"#/*": "./*"
 	}
 }

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -10,6 +10,7 @@
 			"!**/dist/**",
 			"!**/build/**",
 			"!**/.turbo/**",
+			"!**/.claude/**",
 			"!**/coverage/**",
 			"!**/.source/**",
 			"!packages/ui/src/styles.css" // Biome can't parse the oddities of Tailwind syntax


### PR DESCRIPTION
## What
Migrated all relative imports in the family-app to use Node.js subpath imports with the `#/*` pattern.

## Why
- Eliminates complex relative path navigation (`../../../../lib/schemas` → `#/lib/schemas`)
- Improves code readability and maintainability
- Reduces import path errors when moving files
- Follows modern Node.js module resolution practices

## How
- Added `"imports": { "#/*": "./*" }` to package.json
- Updated 8 files across components and API routes
- Replaced all relative imports with clean subpath imports

🤖 Generated with [Claude Code](https://claude.ai/code)