### PR TITLE
Fix shared Next config types

### DIFF
--- a/tooling/next-config/next.config.ts
+++ b/tooling/next-config/next.config.ts
@@ -1,6 +1,4 @@
-import type { NextConfig } from "next";
-
-export const config: NextConfig = {
+export const config = {
 	// We do these in GitHub Actions checks so we don't do them here.
 	eslint: { ignoreDuringBuilds: true },
 	typescript: { ignoreBuildErrors: true },

--- a/tooling/next-config/package.json
+++ b/tooling/next-config/package.json
@@ -2,7 +2,7 @@
 	"name": "@repo/next-config",
 	"exports": {
 		".": {
-			"types": "./dist/next.config.d.ts",
+			"types": "./next.config.ts",
 			"default": "./next.config.ts"
 		}
 	},


### PR DESCRIPTION
## Why
The portfolio typecheck was failing because the shared Next config exported types tied to a different installed Next version than the app uses.

## What
Stop publishing a stale/dist NextConfig type from @repo/next-config and let consumers resolve the source config shape directly.

## How
Verified with pnpm check-types. The push hook also ran pnpm lint successfully.