### PR TITLE
Update pnpm to v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,5 @@
 	"engines": {
 		"node": ">=22"
 	},
-	"packageManager": "pnpm@10.14.0-0+sha512.2cd47a0cbf5f1d1de7693a88307a0ede5be94e0d3b34853d800ee775efbea0650cb562b77605ec80bc8d925f5cd27c4dfe8bb04d3a0b76090784c664450d32d6",
-	"pnpm": {
-		"neverBuiltDependencies": []
-	}
+	"packageManager": "pnpm@11.10.0+sha512.0b7f8b98060031904c017e3a41eb187a16d40eeb829b95c4f8cb03681761fc4ab53dd219115b9b447f4dce1a05a214764461e7d3703392a9f32f9511ce8c86c8"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,9 @@ packages:
   - "!apps/cli-app"
   - packages/*
   - tooling/*
+allowBuilds:
+  '@parcel/watcher': true
+  '@tailwindcss/oxide': true
+  esbuild: true
+  oxc-resolver: true
+  sharp: true


### PR DESCRIPTION
## Why

pnpm 11 is out; staying current keeps us on supported tooling and picks up the new supply-chain lockfile verification.

## What

- Bumped `packageManager` to `pnpm@11.10.0`
- Migrated build-script config: pnpm 11 no longer reads the `pnpm` field in `package.json`, so the old `neverBuiltDependencies: []` (build everything) is replaced by an explicit `allowBuilds` list in `pnpm-workspace.yaml`

## How

`corepack use pnpm@latest`, then filled in the `allowBuilds` stanza pnpm 11 generated, setting all five packages with build scripts to `true` to match previous behavior.

To verify: `pnpm install` should complete with all postinstall scripts running (esbuild, sharp, @parcel/watcher, @tailwindcss/oxide, oxc-resolver) and no `ERR_PNPM_IGNORED_BUILDS` warning. Lockfile is unchanged.