### PR TITLE
Replace blue-tinted grays with neutral grays

### DIFF
--- a/apps/portfolio/app/(portfolio)/blog/[slug]/page.tsx
+++ b/apps/portfolio/app/(portfolio)/blog/[slug]/page.tsx
@@ -85,12 +85,12 @@ async function PostLayout(props: { params: Promise<{ slug: string }> }) {
 					<h1 className="mb-4 text-pretty">{post.title}</h1>
 					<div className="flex flex-row gap-4 align-center">
 						<time
-							className="text-xs text-gray-600 dark:text-gray-400"
+							className="text-xs text-neutral-600 dark:text-neutral-400"
 							dateTime={post.date}
 						>
 							{post.date}
 						</time>
-						<hr className="grow border my-auto! text-slate-900" />
+						<hr className="grow border my-auto! text-neutral-900" />
 					</div>
 				</div>
 			</header>
@@ -99,7 +99,7 @@ async function PostLayout(props: { params: Promise<{ slug: string }> }) {
 				<Mdx components={mdxComponents} />
 			</article>
 
-			<footer className="pt-4 mt-4 border-t-2 border-t-slate-600">
+			<footer className="pt-4 mt-4 border-t-2 border-t-neutral-600">
 				<p className="text-xl font-medium">More Reading</p>
 
 				<div className="flex flex-col justify-center gap-4 sm:flex-row sm:justify-between">

--- a/apps/portfolio/app/(portfolio)/blog/page.tsx
+++ b/apps/portfolio/app/(portfolio)/blog/page.tsx
@@ -16,10 +16,10 @@ export function generateMetadata(): Metadata {
 function PostCard(post: Blog) {
 	return (
 		<Link href={`/blog/${post.info.path.replace(".mdx", "")}`}>
-			<div className="p-4 mb-4 transition-all rounded-lg hover:bg-slate-100 dark:hover:bg-slate-900 md:p-6">
+			<div className="p-4 mb-4 transition-all rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-900 md:p-6">
 				<h2 className="text-xl font-bold">{post.title}</h2>
 				<time
-					className="block mb-2 text-xs text-gray-600 dark:text-gray-500"
+					className="block mb-2 text-xs text-neutral-600 dark:text-neutral-500"
 					dateTime={post.date}
 				>
 					{format(new Date(post.date), "LLLL d, yyyy")}

--- a/apps/portfolio/app/(portfolio)/page.tsx
+++ b/apps/portfolio/app/(portfolio)/page.tsx
@@ -28,7 +28,7 @@ export default function Home() {
 					<h1 className="m-0 text-xl font-bold text-black dark:text-white sm:text-4xl">
 						Anthony Shew
 					</h1>
-					<p className="m-0 mt-1 font-mono text-xs text-pretty sm:text-lg dark:text-slate-400">
+					<p className="m-0 mt-1 font-mono text-xs text-pretty sm:text-lg dark:text-neutral-400">
 						{tagline}
 					</p>
 				</div>

--- a/apps/portfolio/app/(portfolio)/talks/page.tsx
+++ b/apps/portfolio/app/(portfolio)/talks/page.tsx
@@ -28,7 +28,7 @@ export default function Home() {
 			<div className="flex flex-col gap-4 mt-8">
 				{talks.map((conference) => (
 					<a
-						className="flex flex-row justify-between p-4 text-white transition-all rounded-lg bg-slate-800 dark:hover:bg-slate-900"
+						className="flex flex-row justify-between p-4 text-white transition-all rounded-lg bg-neutral-800 dark:hover:bg-neutral-900"
 						href={conference.link}
 						key={conference.confName}
 						rel="nooopener noreferrer"

--- a/packages/ui/src/components/Navbar.tsx
+++ b/packages/ui/src/components/Navbar.tsx
@@ -31,7 +31,7 @@ export function Navbar({
 						key={link.label}
 					>
 						{link.label}
-						<span className="ui:block ui:max-w-0 group-hover:ui:max-w-full ui:transition-all ui:duration-300 ui:h-px ui:bg-slate-800 dark:ui:bg-white" />
+						<span className="ui:block ui:max-w-0 group-hover:ui:max-w-full ui:transition-all ui:duration-300 ui:h-px ui:bg-neutral-800 dark:ui:bg-white" />
 					</Link>
 				);
 			})}


### PR DESCRIPTION
## Why

The site's grays looked blueish. The semantic theme vars in `packages/ui/src/styles.css` are pure zero-chroma grays, but a handful of components used Tailwind's `slate-*` (blue-tinted) and `gray-*` (slightly cool) utilities, causing the tint and inconsistency with the theme.

## What

Swapped all ad-hoc `slate-*` and `gray-*` classes for `neutral-*`, Tailwind's true zero-chroma gray, matching the theme vars.

## How

Class-name-only substitutions across the portfolio pages (home, blog index, blog post, talks) and the shared Navbar. To verify, browse those pages in light and dark mode and confirm text, borders, card backgrounds, and hover states read as pure gray with no blue cast.